### PR TITLE
Dynamically adjust belief and action

### DIFF
--- a/CAN2BigraphERCompiler/bigraph.mli
+++ b/CAN2BigraphERCompiler/bigraph.mli
@@ -83,7 +83,7 @@ val transform_belief : Syntax.belief array -> string array
 val transform_desire : Syntax.desire array -> string array
 (** Transforms the desire array into string array for {!val:str_build_desire}. *)
 
-val belief : string -> string -> string
+val belief : string -> string -> string -> string -> string
 (** Helper function for a [fold_left] that concatenate the beliefs with the good typo.*)
 
 val desire : string -> string -> string
@@ -108,7 +108,7 @@ val find_i : string list array -> string -> int -> int option
 val plan_array_build : string -> Syntax.cond -> string -> unit
 (** Contructs the ref {!val:plans} with BigraphER code.*)
 
-val action_str_build : string -> string -> string -> string -> unit
+val action_str_build : string -> string -> string -> string -> string -> string -> string -> string -> unit
 (** Constructs the ref {!val:actions} with BigraphER code. *)
 
 val fold_merge : string -> string -> string

--- a/CAN2BigraphERCompiler/compile.ml
+++ b/CAN2BigraphERCompiler/compile.ml
@@ -28,8 +28,8 @@ let rec c_action actions =
   match actions with
   | h :: t -> (
       match h with
-      | Action (str, c, del, add) ->
-          action_str_build str (cond c) (set del) (set add);
+      | Action (str, c, del, ac_posv, ac_posv_eff, add, ac_negv, ac_negv_eff) ->
+          action_str_build str (cond c) (set del) ac_posv ac_posv_eff (set add) ac_negv ac_negv_eff;
           c_action t)
   | [] -> ()
 

--- a/CAN2BigraphERCompiler/parser.mly
+++ b/CAN2BigraphERCompiler/parser.mly
@@ -26,11 +26,11 @@ belief_num:
 
 belief_num_t:
     | NUM belief { [(int_of_float (float_of_string $1), $2)] }
-    | NUM { [(int_of_float (float_of_string $1), [|Belief("")|])] }
+    | NUM { [(int_of_float (float_of_string $1), [|Belief("", "", "")|])] }
 
 belief:
     | belief COMMA belief { Array.append $1 $3 }
-    | STRING { Array.make 1 (Belief($1)) }
+    | STRING COLON LA STRING COMMA STRING RA { Array.make 1 (Belief($1, $4, $6)) }
 
 desire:
     | desire COMMA desire { Array.append $1 $3 }
@@ -64,11 +64,8 @@ action :
     | action_t action { Array.append $1 $2 }
 
 action_t :
-    | STRING COLON cond ARROW LA LB set RB COMMA LB set RB RA { Array.make 1 (Action($1, $3, Del($7), Add($11))) }
-    | STRING COLON cond ARROW LA LB RB COMMA LB set RB RA { Array.make 1 (Action($1, $3, Del([|Belief("")|]), Add($10))) }
-    | STRING COLON cond ARROW LA LB set RB COMMA LB RB RA { Array.make 1 (Action($1, $3, Del($7), Add([|Belief("")|]))) }
-    | STRING COLON cond ARROW LA LB RB COMMA LB RB RA { Array.make 1 (Action($1, $3, Del([|Belief("")|]), Add([|Belief("")|]))) }
+    | STRING COLON cond ARROW LA set COLON LB STRING COMMA STRING RB RA COMMA LA set COLON LB STRING COMMA STRING RB RA { Array.make 1 (Action($1, $3, Del($6), $9, $11, Add($16), $19, $21)) }
 
 set :
     | set COMMA set { Array.append $1 $3 }
-    | STRING { Array.make 1 (Belief($1)) }
+    | STRING { Array.make 1 (Belief($1, "", "")) }

--- a/CAN2BigraphERCompiler/precompile.ml
+++ b/CAN2BigraphERCompiler/precompile.ml
@@ -40,18 +40,26 @@ let c_set set =
       Array.iter
         (fun x ->
           match x with
-          | Belief bel -> if not (String.equal bel "") then b_type bel else ())
+          | Belief (bel, posv, negv) ->
+          		b_type bel; 
+              a_type posv; 
+              a_type negv 
+        )
         b
 
 let rec c_action actions =
   match actions with
   | h :: t -> (
       match h with
-      | Action (str, c, del, add) ->
+      | Action (str, c, del, ac_posv, ac_posv_eff, add, ac_negv, ac_negv_eff) ->
           a_type str;
           c_cond c;
           c_set del;
+          a_type ac_posv;
+          a_type ac_posv_eff;
           c_set add;
+          a_type ac_negv;
+          a_type ac_negv_eff;
           c_action t)
   | [] -> ()
 
@@ -70,7 +78,7 @@ let rec c_line line =
       let rec scan l =
         match l with
         | (_, h) :: t ->
-            Array.iter (fun x -> match x with Belief bel -> b_type bel) h;
+            Array.iter (fun x -> match x with Belief (bel, posv, negv) -> b_type bel; a_type posv; a_type negv) h;
             scan t
         | [] -> ()
       in

--- a/CAN2BigraphERCompiler/syntax.ml
+++ b/CAN2BigraphERCompiler/syntax.ml
@@ -7,11 +7,11 @@ type plan_body =
   | Event_Act of string
   | Empty
 
-type belief = Belief of string
+type belief = Belief of string * string * string
 type desire = Desire of string
 type plan = Plan of string * cond * plan_body
 type set = Add of belief array | Del of belief array
-type action = Action of string * cond * set * set
+type action = Action of string * cond * set * string * string * set * string * string
 
 type line =
   | Seq_line of line * line

--- a/CAN2BigraphERCompiler/syntax.mli
+++ b/CAN2BigraphERCompiler/syntax.mli
@@ -18,11 +18,11 @@ type plan_body =
   | Event_Act of string
   | Empty
 
-type belief = Belief of string
+type belief = Belief of string * string * string
 type desire = Desire of string
 type plan = Plan of string * cond * plan_body
 type set = Add of belief array | Del of belief array
-type action = Action of string * cond * set * set
+type action = Action of string * cond * set * string * string * set * string * string
 
 type line =
   | Seq_line of line * line


### PR DESCRIPTION
Dynamically adjust the weight of belief and action. Currently, belief recognizes the following forms

-------------------------------------------------- -------------------------------------------------- -
1. ram_free: <8, 2>, storage_free: <0,0>

There should be two numbers in <> in the form <X, Y> and the
first number (X) is considered as postive_value.
second number(Y) is considered as negative_value.

  Beliefs.(B("ram_free").(Pw(8)| Nw(2)) | B("storage_free").(Pw(0) | Nw(0)))

-------------------------------------------------- --------------------------------------------------

collect_dust : ram_free <- < ram_free: {4, 7} >, < ram_free: {6, 3}>

Similarly, in action <- <action:{X1, Y1}>, <action: {X2, Y2}, it is planned to be translated into

new_big_format: big collect_dust = Act.(Pre.B("ram_free").1 | Effect.(Revise.B("ram_free").Pw(4), EffectWeight(7)) | Effect.(Revise.B(" ram_free").Nw(6), EffectWeight(3)))

X1 represents its postive_value and Y1 represents the EffectWeight of X1
X2 represents its begtive_value and Y2 represents the EffectWeight of X2
-------------------------------------------------- --------------------------------------------------